### PR TITLE
Unit tests added to the library MetalCypher

### DIFF
--- a/MetalCypher.xcodeproj/project.pbxproj
+++ b/MetalCypher.xcodeproj/project.pbxproj
@@ -14,6 +14,10 @@
 		2265FADF1FF15C5000D5D9F4 /* Metal.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 22F583A61F8FD2C300207597 /* Metal.framework */; };
 		22A4ED951F8F06430075BB2B /* Async.m in Sources */ = {isa = PBXBuildFile; fileRef = 22A4ED931F8F06430075BB2B /* Async.m */; };
 		22A4ED991F8F93520075BB2B /* MetalCypher.m in Sources */ = {isa = PBXBuildFile; fileRef = 22A4ED971F8F93520075BB2B /* MetalCypher.m */; };
+		22AEBE731FEB02C700F6E172 /* SharedMD5Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22AEBE721FEB02C700F6E172 /* SharedMD5Tests.swift */; };
+		22AEBE751FEB02C700F6E172 /* libMetalCypher.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 221888761F8ECE8A000731EA /* libMetalCypher.a */; };
+		22AEBE7D1FEB19D200F6E172 /* AsyncTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22AEBE7C1FEB19D200F6E172 /* AsyncTests.swift */; };
+		22AEBE821FEBB13E00F6E172 /* MetalCypherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22AEBE811FEBB13E00F6E172 /* MetalCypherTests.swift */; };
 		22C023AB1F910A8C002DDAC7 /* MD5.h in Headers */ = {isa = PBXBuildFile; fileRef = 22C023A81F910A8C002DDAC7 /* MD5.h */; };
 		22C023AD1F910A8C002DDAC7 /* MD5.metal in Sources */ = {isa = PBXBuildFile; fileRef = 22C023AA1F910A8C002DDAC7 /* MD5.metal */; };
 		22C023AF1F911807002DDAC7 /* Async_Internal.h in Headers */ = {isa = PBXBuildFile; fileRef = 22C023AE1F91174C002DDAC7 /* Async_Internal.h */; };
@@ -25,6 +29,16 @@
 		22F583A81F8FD2C300207597 /* Metal.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 22F583A61F8FD2C300207597 /* Metal.framework */; };
 /* End PBXBuildFile section */
 
+/* Begin PBXContainerItemProxy section */
+		22AEBE761FEB02C700F6E172 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 2218886E1F8ECE8A000731EA /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 221888751F8ECE8A000731EA;
+			remoteInfo = MetalCypher;
+		};
+/* End PBXContainerItemProxy section */
+
 /* Begin PBXFileReference section */
 		22028B9D1FA961F500011876 /* MetalCypher.metal */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.metal; path = MetalCypher.metal; sourceTree = "<group>"; };
 		22028BA41FA9D67E00011876 /* SharedMD5.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = SharedMD5.c; sourceTree = "<group>"; };
@@ -33,6 +47,12 @@
 		221888761F8ECE8A000731EA /* libMetalCypher.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libMetalCypher.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		22A4ED931F8F06430075BB2B /* Async.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = Async.m; sourceTree = "<group>"; };
 		22A4ED971F8F93520075BB2B /* MetalCypher.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = MetalCypher.m; path = MetalCypher/MetalCypher.m; sourceTree = SOURCE_ROOT; };
+		22AEBE701FEB02C600F6E172 /* MetalCypherTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = MetalCypherTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		22AEBE721FEB02C700F6E172 /* SharedMD5Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SharedMD5Tests.swift; sourceTree = "<group>"; };
+		22AEBE741FEB02C700F6E172 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		22AEBE7B1FEB048400F6E172 /* MetalCypherTests-BridgingHeader.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "MetalCypherTests-BridgingHeader.h"; sourceTree = "<group>"; };
+		22AEBE7C1FEB19D200F6E172 /* AsyncTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AsyncTests.swift; sourceTree = "<group>"; };
+		22AEBE811FEBB13E00F6E172 /* MetalCypherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MetalCypherTests.swift; sourceTree = "<group>"; };
 		22C023A71F910A55002DDAC7 /* SharedMD5.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SharedMD5.h; sourceTree = "<group>"; };
 		22C023A81F910A8C002DDAC7 /* MD5.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MD5.h; sourceTree = "<group>"; };
 		22C023AA1F910A8C002DDAC7 /* MD5.metal */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.metal; path = MD5.metal; sourceTree = "<group>"; };
@@ -82,6 +102,7 @@
 			isa = PBXGroup;
 			children = (
 				221888781F8ECE8A000731EA /* MetalCypher */,
+				22AEBE711FEB02C700F6E172 /* MetalCypherTests */,
 				221888771F8ECE8A000731EA /* Products */,
 				22F583A41F8FD2C200207597 /* Frameworks */,
 			);
@@ -91,6 +112,7 @@
 			isa = PBXGroup;
 			children = (
 				221888761F8ECE8A000731EA /* libMetalCypher.a */,
+				22AEBE701FEB02C600F6E172 /* MetalCypherTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -104,6 +126,18 @@
 				22C023A31F9106C2002DDAC7 /* MetalCypher */,
 			);
 			path = MetalCypher;
+			sourceTree = "<group>";
+		};
+		22AEBE711FEB02C700F6E172 /* MetalCypherTests */ = {
+			isa = PBXGroup;
+			children = (
+				22AEBE7B1FEB048400F6E172 /* MetalCypherTests-BridgingHeader.h */,
+				22AEBE741FEB02C700F6E172 /* Info.plist */,
+				22AEBE7C1FEB19D200F6E172 /* AsyncTests.swift */,
+				22AEBE721FEB02C700F6E172 /* SharedMD5Tests.swift */,
+				22AEBE811FEBB13E00F6E172 /* MetalCypherTests.swift */,
+			);
+			path = MetalCypherTests;
 			sourceTree = "<group>";
 		};
 		22C023A31F9106C2002DDAC7 /* MetalCypher */ = {
@@ -180,6 +214,24 @@
 			productReference = 221888761F8ECE8A000731EA /* libMetalCypher.a */;
 			productType = "com.apple.product-type.library.static";
 		};
+		22AEBE6F1FEB02C600F6E172 /* MetalCypherTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 22AEBE7A1FEB02C700F6E172 /* Build configuration list for PBXNativeTarget "MetalCypherTests" */;
+			buildPhases = (
+				22AEBE6C1FEB02C600F6E172 /* Sources */,
+				22AEBE6D1FEB02C600F6E172 /* Frameworks */,
+				22AEBE6E1FEB02C600F6E172 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				22AEBE771FEB02C700F6E172 /* PBXTargetDependency */,
+			);
+			name = MetalCypherTests;
+			productName = MetalCypherTests;
+			productReference = 22AEBE701FEB02C600F6E172 /* MetalCypherTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
@@ -193,6 +245,10 @@
 					221888751F8ECE8A000731EA = {
 						CreatedOnToolsVersion = 9.0;
 						LastSwiftMigration = 0900;
+						ProvisioningStyle = Automatic;
+					};
+					22AEBE6F1FEB02C600F6E172 = {
+						CreatedOnToolsVersion = 9.2;
 						ProvisioningStyle = Automatic;
 					};
 				};
@@ -210,9 +266,20 @@
 			projectRoot = "";
 			targets = (
 				221888751F8ECE8A000731EA /* MetalCypher */,
+				22AEBE6F1FEB02C600F6E172 /* MetalCypherTests */,
 			);
 		};
 /* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		22AEBE6E1FEB02C600F6E172 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
 		221888721F8ECE8A000731EA /* Sources */ = {
@@ -229,7 +296,25 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		22AEBE6C1FEB02C600F6E172 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				22AEBE7D1FEB19D200F6E172 /* AsyncTests.swift in Sources */,
+				22AEBE731FEB02C700F6E172 /* SharedMD5Tests.swift in Sources */,
+				22AEBE821FEBB13E00F6E172 /* MetalCypherTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		22AEBE771FEB02C700F6E172 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 221888751F8ECE8A000731EA /* MetalCypher */;
+			targetProxy = 22AEBE761FEB02C700F6E172 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
 		2218887D1F8ECE8A000731EA /* Debug */ = {
@@ -417,6 +502,15 @@
 			buildConfigurations = (
 				221888801F8ECE8A000731EA /* Debug */,
 				221888811F8ECE8A000731EA /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		22AEBE7A1FEB02C700F6E172 /* Build configuration list for PBXNativeTarget "MetalCypherTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				22AEBE781FEB02C700F6E172 /* Debug */,
+				22AEBE791FEB02C700F6E172 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/MetalCypher.xcodeproj/project.pbxproj
+++ b/MetalCypher.xcodeproj/project.pbxproj
@@ -10,6 +10,8 @@
 		22028B9E1FA961F500011876 /* MetalCypher.metal in Sources */ = {isa = PBXBuildFile; fileRef = 22028B9D1FA961F500011876 /* MetalCypher.metal */; };
 		22028BA51FA9D67E00011876 /* SharedMD5.c in Sources */ = {isa = PBXBuildFile; fileRef = 22028BA41FA9D67E00011876 /* SharedMD5.c */; };
 		220E15ED1FB3A90C007B7B29 /* SharedMD5.metal in Sources */ = {isa = PBXBuildFile; fileRef = 220E15EC1FB3A90C007B7B29 /* SharedMD5.metal */; };
+		2265FADE1FF15C4800D5D9F4 /* MetalKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 22F583A51F8FD2C300207597 /* MetalKit.framework */; };
+		2265FADF1FF15C5000D5D9F4 /* Metal.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 22F583A61F8FD2C300207597 /* Metal.framework */; };
 		22A4ED951F8F06430075BB2B /* Async.m in Sources */ = {isa = PBXBuildFile; fileRef = 22A4ED931F8F06430075BB2B /* Async.m */; };
 		22A4ED991F8F93520075BB2B /* MetalCypher.m in Sources */ = {isa = PBXBuildFile; fileRef = 22A4ED971F8F93520075BB2B /* MetalCypher.m */; };
 		22C023AB1F910A8C002DDAC7 /* MD5.h in Headers */ = {isa = PBXBuildFile; fileRef = 22C023A81F910A8C002DDAC7 /* MD5.h */; };
@@ -49,6 +51,16 @@
 			files = (
 				22F583A71F8FD2C300207597 /* MetalKit.framework in Frameworks */,
 				22F583A81F8FD2C300207597 /* Metal.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		22AEBE6D1FEB02C600F6E172 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				2265FADE1FF15C4800D5D9F4 /* MetalKit.framework in Frameworks */,
+				2265FADF1FF15C5000D5D9F4 /* Metal.framework in Frameworks */,
+				22AEBE751FEB02C700F6E172 /* libMetalCypher.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -174,7 +186,8 @@
 		2218886E1F8ECE8A000731EA /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 0900;
+				LastSwiftUpdateCheck = 0920;
+				LastUpgradeCheck = 0920;
 				ORGANIZATIONNAME = "ArcTouch, Inc.";
 				TargetAttributes = {
 					221888751F8ECE8A000731EA = {
@@ -319,6 +332,7 @@
 				MACOSX_DEPLOYMENT_TARGET = 10.13;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = macosx;
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
 			};
 			name = Release;
 		};
@@ -348,6 +362,41 @@
 				MTL_PREPROCESSOR_DEFINITIONS = METAL;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 3.0;
+			};
+			name = Release;
+		};
+		22AEBE781FEB02C700F6E172 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				COMBINE_HIDPI_IMAGES = YES;
+				DEVELOPMENT_TEAM = 5HMJW6N276;
+				INFOPLIST_FILE = MetalCypherTests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
+				OTHER_LDFLAGS = "-ObjC";
+				PRODUCT_BUNDLE_IDENTIFIER = flores.julio.MetalCypherTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OBJC_BRIDGING_HEADER = "${PROJECT_DIR}/MetalCypherTests/MetalCypherTests-BridgingHeader.h";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 4.0;
+			};
+			name = Debug;
+		};
+		22AEBE791FEB02C700F6E172 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				COMBINE_HIDPI_IMAGES = YES;
+				DEVELOPMENT_TEAM = 5HMJW6N276;
+				INFOPLIST_FILE = MetalCypherTests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
+				OTHER_LDFLAGS = "-ObjC";
+				PRODUCT_BUNDLE_IDENTIFIER = flores.julio.MetalCypherTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_OBJC_BRIDGING_HEADER = "${PROJECT_DIR}/MetalCypherTests/MetalCypherTests-BridgingHeader.h";
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				SWIFT_VERSION = 4.0;
 			};
 			name = Release;
 		};

--- a/MetalCypher/Async_Internal.m
+++ b/MetalCypher/Async_Internal.m
@@ -2,7 +2,7 @@
 //  Async_Internal.c
 //  MetalCypher
 //
-//  Created by Office on 13/10/17.
+//  Created by Julio Flores on 13/10/17.
 //
 
 #import "Async_Internal.h"

--- a/MetalCypher/MetalCypher.m
+++ b/MetalCypher/MetalCypher.m
@@ -51,19 +51,15 @@
     return nil;
   }
   
+  NSBundle * libraryBundle = [NSBundle bundleWithPath:[[NSProcessInfo processInfo] environment][@"PWD"]];
   device          = MTLCreateSystemDefaultDevice();
-  defaultLibrary  = [device newDefaultLibrary];
+  defaultLibrary  = [device newDefaultLibraryWithBundle:libraryBundle error:nil];
   commandQueue    = [device newCommandQueue];
   hashBuffer      = [device newBufferWithLength:HASH_SIZE     options:MTLResourceOptionCPUCacheModeWriteCombined];
   inputBuffer     = [device newBufferWithLength:sizeof(uint)  options:MTLResourceOptionCPUCacheModeWriteCombined];
   matchBuffer     = [device newBufferWithLength:sizeof(uint)  options:MTLResourceStorageModeShared];
   
-  MTLComputePipelineDescriptor * pipelineDescriptor = [MTLComputePipelineDescriptor new];
-  [pipelineDescriptor setComputeFunction:[defaultLibrary newFunctionWithName:kernelBruteForce]];
-  [pipelineDescriptor setLabel:@"Brute Force Pipeline"];
-  [pipelineDescriptor setThreadGroupSizeIsMultipleOfThreadExecutionWidth:YES];
-  
-  pipeline = [device newComputePipelineStateWithDescriptor:pipelineDescriptor options:MTLPipelineOptionBufferTypeInfo reflection:nil error:nil];
+  pipeline = [device newComputePipelineStateWithFunction:[defaultLibrary newFunctionWithName:kernelBruteForce] error:nil];
   
   trials = 0;
   password = [MD5Result new];
@@ -87,19 +83,16 @@
     return nil;
   }
   
+  NSBundle * libraryBundle = [NSBundle bundleWithPath:[[NSProcessInfo processInfo] environment][@"PWD"]];
+  
   device          = MTLCreateSystemDefaultDevice();
-  defaultLibrary  = [device newDefaultLibrary];
+  defaultLibrary  = [device newDefaultLibraryWithBundle:libraryBundle error:nil];
   commandQueue    = [device newCommandQueue];
   inputBuffer     = [device newBufferWithLength:[thePassword length]  options:MTLResourceOptionCPUCacheModeWriteCombined];
   inputSizeBuffer = [device newBufferWithLength:sizeof(uint)          options:MTLResourceOptionCPUCacheModeWriteCombined];
   outputBuffer    = [device newBufferWithLength:sizeof(uint)          options:MTLResourceStorageModeShared];
   
-  MTLComputePipelineDescriptor * pipelineDescriptor = [MTLComputePipelineDescriptor new];
-  [pipelineDescriptor setComputeFunction:[defaultLibrary newFunctionWithName:kernelHashify]];
-  [pipelineDescriptor setLabel:@"Hashify Pipeline"];
-  [pipelineDescriptor setThreadGroupSizeIsMultipleOfThreadExecutionWidth:NO];
-  
-  pipeline = [device newComputePipelineStateWithDescriptor:pipelineDescriptor options:MTLPipelineOptionBufferTypeInfo reflection:nil error:nil];
+  pipeline = [device newComputePipelineStateWithFunction:[defaultLibrary newFunctionWithName:kernelHashify] error:nil];
   
   password = [MD5Result new];
   hash = [MD5Result new];

--- a/MetalCypherTests/AsyncTests.swift
+++ b/MetalCypherTests/AsyncTests.swift
@@ -1,0 +1,38 @@
+//
+//  AsyncTests.swift
+//  MetalCypherTests
+//
+//  Created by Julio Flores on 20/12/17.
+//
+
+import XCTest
+
+class AsyncTests: XCTestCase {
+  func testAsyncResultFiringAfterSettingValue() {
+    let asyncResult = Async<NSString>()
+    let anyString = "A string to be tested"
+    var stringToMatch = ""
+    
+    asyncResult.result = { theResult in
+      stringToMatch = theResult as String
+    }
+    
+    XCTAssertEqual(stringToMatch, "")
+    asyncResult.value = anyString as NSString
+    XCTAssertEqual(stringToMatch, anyString)
+  }
+  
+  func testAsyncResultFiringImmediatelyBecauseValueIsAlreadySet() {
+    let asyncResult = Async<NSString>()
+    let anyString = "A string to be tested"
+    var stringToMatch = ""
+    
+    asyncResult.value = anyString as NSString
+    
+    asyncResult.result = { theResult in
+      stringToMatch = theResult as String
+    }
+    
+    XCTAssertEqual(stringToMatch, anyString)
+  }
+}

--- a/MetalCypherTests/Info.plist
+++ b/MetalCypherTests/Info.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>BNDL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+</dict>
+</plist>

--- a/MetalCypherTests/MetalCypherTests-BridgingHeader.h
+++ b/MetalCypherTests/MetalCypherTests-BridgingHeader.h
@@ -1,0 +1,16 @@
+//
+//  MetalCypherTests-BridgingHeader.h
+//  MetalCypher
+//
+//  Created by Julio Flores on 20/12/17.
+//
+
+#ifndef MetalCypherTests_BridgingHeader_h
+#define MetalCypherTests_BridgingHeader_h
+
+#import "../MetalCypher/SharedMD5.h"
+#import "../MetalCypher/Async_Internal.h"
+#import "../MetalCypher/Async.h"
+#import "../MetalCypher/MetalCypher.h"
+
+#endif /* MetalCypherTests_BridgingHeader_h */

--- a/MetalCypherTests/MetalCypherTests.swift
+++ b/MetalCypherTests/MetalCypherTests.swift
@@ -1,0 +1,105 @@
+//
+//  MetalCypherTests.swift
+//  MetalCypherTests
+//
+//  Created by Julio Flores on 21/12/17.
+//
+
+import XCTest
+
+class MetalCypherTests: XCTestCase {
+  private enum Error: Swift.Error {
+    case isNotEven, isNotHexadecimal
+  }
+  
+  func testHashifyPassword() {
+    let passwordToMatch = "lalalones"
+    let hashToMatch = "2a02361bcbf503bcab5f2ca312cca383"
+    
+    guard let passwordData = passwordToMatch.data(using: .ascii) else {
+      XCTFail("The password is generating no bytes")
+      return
+    }
+    let hashifier = MetalCypher(password: passwordData)
+    let expectPasswordToMatch = expectation(description: "Matching password")
+    let expectHashToMatch = expectation(description: "Matching hash")
+    
+    hashifier.password.result = { passwordData in
+      let password = String(data: passwordData as Data, encoding: .ascii)
+      
+      XCTAssertEqual(passwordToMatch, password)
+      expectPasswordToMatch.fulfill()
+    }
+    hashifier.hash.result = { hashData in
+      let hash = self.convertToString(theHashData: hashData)
+      
+      XCTAssertEqual(hashToMatch, hash)
+      expectHashToMatch.fulfill()
+    }
+    
+    waitForExpectations(timeout: 1.0)
+  }
+  
+  func testBruteForceHash() {
+    let passwordToMatch = "la"
+    let hashToMatch = "c9089f3c9adaf0186f6ffb1ee8d6501c"
+    
+    guard let hashData = try? convertToData(theStringifiedHash: hashToMatch) else {
+      XCTFail("The hash characters count isn't even or is not hexadecimal.")
+      return
+    }
+    let hashifier = MetalCypher(hash: hashData)
+    let expectPasswordToMatch = expectation(description: "Matching password")
+    let expectHashToMatch = expectation(description: "Matching hash")
+    
+    hashifier.password.result = { passwordData in
+      let password = String(data: passwordData as Data, encoding: .ascii)
+      
+      XCTAssertEqual(passwordToMatch, password)
+      expectPasswordToMatch.fulfill()
+    }
+    hashifier.hash.result = { hashData in
+      let hash = self.convertToString(theHashData: hashData)
+      
+      XCTAssertEqual(hashToMatch, hash)
+      expectHashToMatch.fulfill()
+    }
+    
+    waitForExpectations(timeout: 1.0)
+  }
+  
+  private func convertToString(theHashData hashData: NSData) -> String {
+    let hashPointer = hashData.bytes.assumingMemoryBound(to: UInt8.self)
+    let hashBuffer = UnsafeBufferPointer(start: hashPointer, count: 16)
+    let hashBytes = Array(hashBuffer)
+    let hash = hashBytes.reduce("", { $0.appendingFormat("%02x", $1) })
+    
+    return hash
+  }
+  
+  private func convertToData(theStringifiedHash hashString: String) throws -> Data {
+    guard hashString.count % 2 == 0 else {
+      throw Error.isNotEven
+    }
+    
+    var hex = String()
+    var hashBytes = [UInt8]()
+    
+    for (i, char) in hashString.enumerated() {
+      let shouldWrapUpHex = i % 2 == 1
+      if !shouldWrapUpHex {
+        hex = "0x\(char)"
+      } else {
+        hex.append(char)
+        let scanner = Scanner(string: hex)
+        var integer: UInt32 = 0
+        guard scanner.scanHexInt32(&integer) else {
+          throw Error.isNotHexadecimal
+        }
+        hashBytes.append(UInt8(integer))
+      }
+    }
+    
+    return Data(bytes: hashBytes)
+  }
+}

--- a/MetalCypherTests/SharedMD5Tests.swift
+++ b/MetalCypherTests/SharedMD5Tests.swift
@@ -1,0 +1,58 @@
+//
+//  SharedMD5Tests.swift
+//  SharedMD5Tests
+//
+//  Created by Julio Flores on 20/12/17.
+//
+
+import XCTest
+
+class SharedMD5Tests: XCTestCase {
+  func testPasswordFrom() {
+    let passwordToMatch = "la"
+    let bytesToMatch = passwordToMatch.utf8.map({ $0 as UInt8 })
+    
+    let index: UInt32 = 24940 // this number is equivalent to "la" when i.e. chars "\0" = 0, chars "\0\0" = 256, and so on
+    var passwordLength: UInt32 = 0
+    let outputPointer = UnsafeMutablePointer<UInt8>.allocate(capacity: 10)
+    
+    passwordFrom(index, outputPointer, &passwordLength)
+    
+    var output = [UInt8]()
+    for i in 0 ..< Int(passwordLength) {
+      output.append(outputPointer.advanced(by: i).pointee)
+    }
+    
+    XCTAssertEqual(bytesToMatch, output)
+  }
+  
+  func testEncode() {
+    let match: [UInt8] = [0b01101001, 0b11110000, 0b00001111, 0b11111111]
+    var input: UInt32 = 0b11111111_00001111_11110000_01101001
+    let outputPointer = UnsafeMutablePointer<UInt8>.allocate(capacity: match.count)
+    var output = [UInt8]()
+    
+    encode(&input, outputPointer, 1)
+    
+    for i in 0 ..< match.count {
+      output.append(outputPointer.advanced(by: i).pointee)
+    }
+    
+    XCTAssertEqual(match, output)
+  }
+  
+  func testDecode() {
+    let match: UInt32 = 0b11111111_00001111_11110000_01101001
+    let input: [UInt8] = [0b01101001, 0b11110000, 0b00001111, 0b11111111]
+    let inputPointer = UnsafeMutablePointer<UInt8>.allocate(capacity: input.count)
+    var output: UInt32 = 0
+    
+    for i in 0 ..< input.count {
+      inputPointer.advanced(by: i).pointee = input[i]
+    }
+    
+    decode(inputPointer, &output, UInt32(input.count))
+    
+    XCTAssertEqual(match, output)
+  }
+}

--- a/SwiftCypher.xcodeproj/project.pbxproj
+++ b/SwiftCypher.xcodeproj/project.pbxproj
@@ -7,6 +7,14 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		222490131FF16D2200AC1E3C /* HashifierTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 222490121FF16D2200AC1E3C /* HashifierTests.swift */; };
+		222490141FF16D3300AC1E3C /* Hashifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22F39FA51FD6C49F007CFF1F /* Hashifier.swift */; };
+		222490151FF16D3600AC1E3C /* Revealer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22F39FA31FD6BDFD007CFF1F /* Revealer.swift */; };
+		222490161FF16D8900AC1E3C /* libMetalCypher.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 22C023CA1F914D6F002DDAC7 /* libMetalCypher.a */; };
+		222490171FF16D9000AC1E3C /* Metal.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 22C023CC1F914D78002DDAC7 /* Metal.framework */; };
+		222490181FF16D9000AC1E3C /* MetalKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 22C023CB1F914D78002DDAC7 /* MetalKit.framework */; };
+		2224901B1FF5ADA500AC1E3C /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22C023C11F914D45002DDAC7 /* main.swift */; };
+		2224901D1FF5AE4D00AC1E3C /* RevealerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2224901C1FF5AE4D00AC1E3C /* RevealerTests.swift */; };
 		22C023C21F914D45002DDAC7 /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22C023C11F914D45002DDAC7 /* main.swift */; };
 		22C023C91F914D6F002DDAC7 /* libMetalCypher.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 22C023CA1F914D6F002DDAC7 /* libMetalCypher.a */; };
 		22C023CD1F914D78002DDAC7 /* MetalKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 22C023CB1F914D78002DDAC7 /* MetalKit.framework */; };
@@ -16,6 +24,10 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		2224900A1FF16CF600AC1E3C /* SwiftCypherTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = SwiftCypherTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		2224900E1FF16CF600AC1E3C /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		222490121FF16D2200AC1E3C /* HashifierTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HashifierTests.swift; sourceTree = "<group>"; };
+		2224901C1FF5AE4D00AC1E3C /* RevealerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RevealerTests.swift; sourceTree = "<group>"; };
 		22C023BE1F914D45002DDAC7 /* SwiftCypher */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = SwiftCypher; sourceTree = BUILT_PRODUCTS_DIR; };
 		22C023C11F914D45002DDAC7 /* main.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = main.swift; sourceTree = "<group>"; };
 		22C023CA1F914D6F002DDAC7 /* libMetalCypher.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; path = libMetalCypher.a; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -27,6 +39,16 @@
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
+		222490071FF16CF600AC1E3C /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				222490171FF16D9000AC1E3C /* Metal.framework in Frameworks */,
+				222490181FF16D9000AC1E3C /* MetalKit.framework in Frameworks */,
+				222490161FF16D8900AC1E3C /* libMetalCypher.a in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		22C023BB1F914D45002DDAC7 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -40,10 +62,21 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		2224900B1FF16CF600AC1E3C /* SwiftCypherTests */ = {
+			isa = PBXGroup;
+			children = (
+				2224900E1FF16CF600AC1E3C /* Info.plist */,
+				222490121FF16D2200AC1E3C /* HashifierTests.swift */,
+				2224901C1FF5AE4D00AC1E3C /* RevealerTests.swift */,
+			);
+			path = SwiftCypherTests;
+			sourceTree = "<group>";
+		};
 		22C023B51F914D45002DDAC7 = {
 			isa = PBXGroup;
 			children = (
 				22C023C01F914D45002DDAC7 /* SwiftCypher */,
+				2224900B1FF16CF600AC1E3C /* SwiftCypherTests */,
 				22C023BF1F914D45002DDAC7 /* Products */,
 				22C023C81F914D6F002DDAC7 /* Frameworks */,
 			);
@@ -53,6 +86,7 @@
 			isa = PBXGroup;
 			children = (
 				22C023BE1F914D45002DDAC7 /* SwiftCypher */,
+				2224900A1FF16CF600AC1E3C /* SwiftCypherTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -81,6 +115,23 @@
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
+		222490091FF16CF600AC1E3C /* SwiftCypherTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 2224900F1FF16CF600AC1E3C /* Build configuration list for PBXNativeTarget "SwiftCypherTests" */;
+			buildPhases = (
+				222490061FF16CF600AC1E3C /* Sources */,
+				222490071FF16CF600AC1E3C /* Frameworks */,
+				222490081FF16CF600AC1E3C /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = SwiftCypherTests;
+			productName = SwiftCypherTests;
+			productReference = 2224900A1FF16CF600AC1E3C /* SwiftCypherTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 		22C023BD1F914D45002DDAC7 /* SwiftCypher */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = 22C023C51F914D45002DDAC7 /* Build configuration list for PBXNativeTarget "SwiftCypher" */;
@@ -103,10 +154,15 @@
 		22C023B61F914D45002DDAC7 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastSwiftUpdateCheck = 0900;
+				LastSwiftUpdateCheck = 0920;
 				LastUpgradeCheck = 0900;
 				ORGANIZATIONNAME = ArcTouch;
 				TargetAttributes = {
+					222490091FF16CF600AC1E3C = {
+						CreatedOnToolsVersion = 9.2;
+						LastSwiftMigration = 0920;
+						ProvisioningStyle = Automatic;
+					};
 					22C023BD1F914D45002DDAC7 = {
 						CreatedOnToolsVersion = 9.0;
 						ProvisioningStyle = Automatic;
@@ -126,11 +182,34 @@
 			projectRoot = "";
 			targets = (
 				22C023BD1F914D45002DDAC7 /* SwiftCypher */,
+				222490091FF16CF600AC1E3C /* SwiftCypherTests */,
 			);
 		};
 /* End PBXProject section */
 
+/* Begin PBXResourcesBuildPhase section */
+		222490081FF16CF600AC1E3C /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
 /* Begin PBXSourcesBuildPhase section */
+		222490061FF16CF600AC1E3C /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				222490131FF16D2200AC1E3C /* HashifierTests.swift in Sources */,
+				222490141FF16D3300AC1E3C /* Hashifier.swift in Sources */,
+				2224901B1FF5ADA500AC1E3C /* main.swift in Sources */,
+				222490151FF16D3600AC1E3C /* Revealer.swift in Sources */,
+				2224901D1FF5AE4D00AC1E3C /* RevealerTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		22C023BA1F914D45002DDAC7 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -144,6 +223,45 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin XCBuildConfiguration section */
+		222490101FF16CF600AC1E3C /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_STYLE = Automatic;
+				COMBINE_HIDPI_IMAGES = YES;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				DEVELOPMENT_TEAM = 5HMJW6N276;
+				HEADER_SEARCH_PATHS = "$(SRCROOT)";
+				INFOPLIST_FILE = SwiftCypherTests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
+				ONLY_ACTIVE_ARCH = YES;
+				OTHER_LDFLAGS = "-ObjC";
+				PRODUCT_BUNDLE_IDENTIFIER = flores.julio.SwiftCypherTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_OBJC_BRIDGING_HEADER = "$(SRCROOT)/SwiftCypher/SwiftCypher-Bridging-Header.h";
+				SWIFT_VERSION = 4.0;
+			};
+			name = Debug;
+		};
+		222490111FF16CF600AC1E3C /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_STYLE = Automatic;
+				COMBINE_HIDPI_IMAGES = YES;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEVELOPMENT_TEAM = 5HMJW6N276;
+				HEADER_SEARCH_PATHS = "$(SRCROOT)";
+				INFOPLIST_FILE = SwiftCypherTests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
+				OTHER_LDFLAGS = "-ObjC";
+				PRODUCT_BUNDLE_IDENTIFIER = flores.julio.SwiftCypherTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_OBJC_BRIDGING_HEADER = "$(SRCROOT)/SwiftCypher/SwiftCypher-Bridging-Header.h";
+				SWIFT_VERSION = 4.0;
+			};
+			name = Release;
+		};
 		22C023C31F914D45002DDAC7 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -174,9 +292,7 @@
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				CODE_SIGN_IDENTITY = "Mac Developer";
 				COPY_PHASE_STRIP = NO;
-				DEBUG_INFORMATION_FORMAT = dwarf;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				ENABLE_TESTABILITY = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_NO_COMMON_BLOCKS = YES;
@@ -193,7 +309,6 @@
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				MACOSX_DEPLOYMENT_TARGET = 10.13;
 				MTL_ENABLE_DEBUG_INFO = YES;
-				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = macosx;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
@@ -230,7 +345,6 @@
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				CODE_SIGN_IDENTITY = "Mac Developer";
 				COPY_PHASE_STRIP = NO;
-				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
@@ -253,8 +367,10 @@
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = 5HMJW6N276;
+				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
 				HEADER_SEARCH_PATHS = "$(SRCROOT)";
 				OTHER_LDFLAGS = "-ObjC";
+				PRODUCT_BUNDLE_IDENTIFIER = flores.julio.SwiftCypher;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "$(SRCROOT)/SwiftCypher/SwiftCypher-Bridging-Header.h";
 				SWIFT_VERSION = 4.0;
@@ -266,8 +382,10 @@
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = 5HMJW6N276;
+				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
 				HEADER_SEARCH_PATHS = "$(SRCROOT)";
 				OTHER_LDFLAGS = "-ObjC";
+				PRODUCT_BUNDLE_IDENTIFIER = flores.julio.SwiftCypher;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "$(SRCROOT)/SwiftCypher/SwiftCypher-Bridging-Header.h";
 				SWIFT_VERSION = 4.0;
@@ -277,6 +395,15 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		2224900F1FF16CF600AC1E3C /* Build configuration list for PBXNativeTarget "SwiftCypherTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				222490101FF16CF600AC1E3C /* Debug */,
+				222490111FF16CF600AC1E3C /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 		22C023B91F914D45002DDAC7 /* Build configuration list for PBXProject "SwiftCypher" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (

--- a/SwiftCypherTests/HashifierTests.swift
+++ b/SwiftCypherTests/HashifierTests.swift
@@ -1,0 +1,52 @@
+//
+//  HashifierTests.swift
+//  HashifierTests
+//
+//  Created by Julio Flores on 22/12/17.
+//
+
+import XCTest
+
+class HashifierTests: XCTestCase {
+  private static let password = "lalalones"
+  private static let hashToMatch = "2a02361bcbf503bcab5f2ca312cca383"
+  
+  func testHashifierDirectly() {
+    let hashifier = Hashifier(password: HashifierTests.password)
+    let hashifyExpectation = expectation(description: "Hashify")
+    
+    do {
+      try hashifier.hashify { [weak self] data in
+        guard let `self` = self else { return }
+        let generatedHash = self.convertToString(theHashData: data)
+        
+        XCTAssertEqual(HashifierTests.hashToMatch, generatedHash)
+        hashifyExpectation.fulfill()
+      }
+      
+      waitForExpectations(timeout: 1.0)
+    } catch let error {
+      XCTFail("Error while hashing password: \(error)")
+    }
+  }
+  
+  func testHashifierDirectlyPerformance() {
+    self.measure(testHashifierDirectly)
+  }
+  
+  func testHashifierViaCommandLinePerformance() {
+    self.measure {
+      CommandLine.arguments[CommandLineArguments.argument.rawValue] = HashifierTests.password
+      hashify()
+    }
+  }
+  
+  private func convertToString(theHashData hashData: NSData) -> String {
+    let hashPointer = hashData.bytes.assumingMemoryBound(to: UInt8.self)
+    let hashBuffer = UnsafeBufferPointer(start: hashPointer, count: 16)
+    let hashBytes = Array(hashBuffer)
+    let hash = hashBytes.reduce("", { $0.appendingFormat("%02x", $1) })
+    
+    return hash
+  }
+}

--- a/SwiftCypherTests/Info.plist
+++ b/SwiftCypherTests/Info.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>BNDL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+</dict>
+</plist>

--- a/SwiftCypherTests/RevealerTests.swift
+++ b/SwiftCypherTests/RevealerTests.swift
@@ -1,0 +1,40 @@
+//
+//  RevealerTests.swift
+//  SwiftCypherTests
+//
+//  Created by Julio Flores on 28/12/17.
+//
+
+import XCTest
+
+class RevealerTests: XCTestCase {
+  private static let hashToReveal = "c9089f3c9adaf0186f6ffb1ee8d6501c"
+  private static let passwordToMatch = "la"
+  
+  func testRevealerDirectly() {
+    let passwordExpectation = expectation(description: "Revealing password expectation")
+    do {
+      let revealer = try Revealer(hash: RevealerTests.hashToReveal)
+      revealer.reveal(result: { password in
+        XCTAssertEqual(RevealerTests.passwordToMatch, password)
+        passwordExpectation.fulfill()
+      }, error: { error in
+        XCTFail("Error while brute forcing the hash: \(error)")
+      })
+    } catch let error {
+      XCTFail("Error while brute forcing the hash: \(error)")
+    }
+    waitForExpectations(timeout: 1.0)
+  }
+  
+  func testRevealerDirectlyPerformance() {
+    self.measure(testRevealerDirectly)
+  }
+  
+  func testRevealerViaCommandLinePerformance() {
+    self.measure {
+      CommandLine.arguments[CommandLineArguments.argument.rawValue] = RevealerTests.hashToReveal
+      reveal()
+    }
+  }
+}


### PR DESCRIPTION
The Unit Tests that involve Metal are not passing because I can't manage Metal to work under the unit test environment, where the MTL Device's Default Library is not loading (i.e. returns nil)