### PR TITLE
Adjust brute force to allow more tests

### DIFF
--- a/MetalCypher/MetalCypher.metal
+++ b/MetalCypher/MetalCypher.metal
@@ -9,24 +9,27 @@
 #include "MD5.h"
 #include "SharedMD5.h"
 
+#define LONGEST_PROBABILITY_TEST_COUNT_PRECISION 8 // an 8-byte number would give us 18.446.744.073.709.551.615 test possibilities
+
 using namespace metal;
 
 kernel void bruteForce(constant uint4 const * hash      [[buffer(BruteForceParameterHash)]],
-                       constant uint  const * input     [[buffer(BruteForceParameterInput)]],
+                       constant uint2 const * input     [[buffer(BruteForceParameterInput)]],
                        device   atomic_uint * match     [[buffer(BruteForceParameterMatch)]],
                        thread   uint          threadID  [[thread_position_in_grid]]) {
   if (atomic_load_explicit(match, memory_order_relaxed) > 0) return;
   
-  thread byte password[MAX_PASSWORD_LENGTH];
+  thread byte password[LONGEST_PROBABILITY_TEST_COUNT_PRECISION];
   thread uint passwordSize;
   
-  passwordFrom(*input + threadID, password, &passwordSize);
+  uint64 localInput = ((uint64)input->y << sizeof(word) * BYTE_SIZE_IN_BITS) | (input->x);
+  passwordFrom(localInput + threadID, password, &passwordSize);
+  
   thread MD5 md5(password, passwordSize);
-
   thread bool nonMatching = (hash->x ^ md5.output.x) | (hash->y ^ md5.output.y) | (hash->z ^ md5.output.z) | (hash->w ^ md5.output.w);
   
   thread uint mask = 0;
-  thread size_t uintSizeInBits = sizeof(uint) * BYTE_SIZE_IN_BITS;
+  thread uint64 uintSizeInBits = sizeof(uint) * BYTE_SIZE_IN_BITS;
   for (thread uint i = 0; i < uintSizeInBits; i++) {
     mask |= nonMatching << i;
   }

--- a/MetalCypher/SharedMD5.h
+++ b/MetalCypher/SharedMD5.h
@@ -22,7 +22,7 @@ using namespace metal;
 #define uint unsigned int
 #endif
 
-#define MAX_PASSWORD_LENGTH 3
+#define MAX_PASSWORD_LENGTH 4
 #define BYTE_SIZE_IN_BITS   8
 #define HASH_SIZE           16
 #define BIGGEST_ASCII_DIGIT 0xff
@@ -46,7 +46,7 @@ typedef enum {
 
 /// Method declarations
 #pragma mark - Method declarations
-void passwordFrom(uint index, thread byte * output, thread uint * outputSize);
+void passwordFrom(uint64 index, thread byte * output, thread uint * outputSize);
 void encode(thread word const * const input, thread byte* output, uint inputSize);
 void decode(thread byte const * const input, thread word* output, uint inputSize);
 

--- a/MetalCypher/SharedMD5.h
+++ b/MetalCypher/SharedMD5.h
@@ -17,9 +17,16 @@ using namespace metal;
 
 /// Definitions
 #pragma mark - Definitions
-#ifndef METAL
+#ifdef METAL
+
+#define uint64 size_t
+
+#else
+
+#define uint    unsigned int
+#define uint64  unsigned long long
 #define thread
-#define uint unsigned int
+
 #endif
 
 #define MAX_PASSWORD_LENGTH 4

--- a/MetalCypher/SharedMD5.shared
+++ b/MetalCypher/SharedMD5.shared
@@ -5,7 +5,7 @@
 //  Created by Julio Flores on 01/11/17.
 //
 
-void passwordFrom(uint index, thread byte * output, thread uint * outputSize) {
+void passwordFrom(uint64 index, thread byte * output, thread uint * outputSize) {
   // avoiding a crash when index = 0 (which may lead to null pointer access) 
   if (!index) {
     *output = 0;
@@ -14,7 +14,7 @@ void passwordFrom(uint index, thread byte * output, thread uint * outputSize) {
   }
   
   uint operationSize = sizeof(word);
-  encode(&index, output, 1);
+  encode((thread word *)&index, output, 2);
   
   for (uint i = operationSize - 1; output[i] == 0; i--) {
     operationSize--;
@@ -33,7 +33,7 @@ void encode(thread word const * const input, thread byte * output, uint inputSiz
 
 void decode(thread byte const * const input, thread word * output, uint inputSize) {
   for (uint i = 0, j = 0, s = 0; i < inputSize; j = ++i / sizeof(word), s = i % sizeof(word)) {
-    if (s == 0) output[j] = 0;
+    if (!s) output[j] = 0;
     output[j] |= input[i] << (BYTE_SIZE_IN_BITS * s);
   }
 }

--- a/MetalCypherTests/SharedMD5Tests.swift
+++ b/MetalCypherTests/SharedMD5Tests.swift
@@ -12,7 +12,7 @@ class SharedMD5Tests: XCTestCase {
     let passwordToMatch = "la"
     let bytesToMatch = passwordToMatch.utf8.map({ $0 as UInt8 })
     
-    let index: UInt32 = 24940 // this number is equivalent to "la" when i.e. chars "\0" = 0, chars "\0\0" = 256, and so on
+    let index: UInt64 = 24940 // this index is equivalent to "la" (ASCII indices "\0" = 0, "\1" = 1, ... "a" = 97, "b" = 98, ... "aa" = 24673, ... "la" = 24940)
     var passwordLength: UInt32 = 0
     let outputPointer = UnsafeMutablePointer<UInt8>.allocate(capacity: 10)
     


### PR DESCRIPTION
32-bit integers related to the test count were replaced by 64-bit integers.
As 64-bit integers are not allowed to be input parameters on Metal,
the bruteForce `input` parameter was made a vector of type int2,
the 64-bit input integer was split in two 32-bit integers in order to be
transported from CPU to GPU, and then put back as an unique 64-bit integer
on Metal side.